### PR TITLE
Remove fmt::Debug requirement from success type in assert_ok

### DIFF
--- a/src/assert_ok/assert_ok.rs
+++ b/src/assert_ok/assert_ok.rs
@@ -42,15 +42,15 @@ macro_rules! assert_ok_as_result {
         match ($a) {
             a => match (a) {
                 Ok(a1) => Ok(a1),
-                _ => Err(format!(
+                Err(e) => Err(format!(
                     concat!(
                         "assertion failed: `assert_ok!(a)`\n",
                         "https://docs.rs/assertables/9.8.2/assertables/macro.assert_ok.html\n",
                         " a label: `{}`,\n",
-                        " a debug: `{:?}`",
+                        " a.unwrap_err() debug: `{:?}`",
                     ),
                     stringify!($a),
-                    a
+                    e
                 )),
             },
         }
@@ -96,7 +96,7 @@ mod test_assert_ok_as_result {
             "assertion failed: `assert_ok!(a)`\n",
             "https://docs.rs/assertables/9.8.2/assertables/macro.assert_ok.html\n",
             " a label: `a`,\n",
-            " a debug: `Err(1)`",
+            " a.unwrap_err() debug: `1`",
         );
         assert_eq!(actual.unwrap_err(), message);
     }
@@ -130,13 +130,13 @@ mod test_assert_ok_as_result {
 /// // assertion failed: `assert_ok!(a)`
 /// // https://docs.rs/assertables/…/assertables/macro.assert_ok.html
 /// //  a label: `a`,
-/// //  a debug: `Err(1)`
+/// //  a.unwrap_err() debug: `1`
 /// # let actual = result.unwrap_err().downcast::<String>().unwrap().to_string();
 /// # let message = concat!(
 /// #     "assertion failed: `assert_ok!(a)`\n",
 /// #     "https://docs.rs/assertables/9.8.2/assertables/macro.assert_ok.html\n",
 /// #     " a label: `a`,\n",
-/// #     " a debug: `Err(1)`",
+/// #     " a.unwrap_err() debug: `1`",
 /// # );
 /// # assert_eq!(actual, message);
 /// # }
@@ -187,7 +187,7 @@ mod test_assert_ok {
             "assertion failed: `assert_ok!(a)`\n",
             "https://docs.rs/assertables/9.8.2/assertables/macro.assert_ok.html\n",
             " a label: `a`,\n",
-            " a debug: `Err(1)`",
+            " a.unwrap_err() debug: `1`",
         );
         assert_eq!(
             result


### PR DESCRIPTION
`assert_ok` currently requires the success type to inherit `fmt::Debug` even though it is guaranteed to never be printed. This is because the panic message debug prints the result value rather than just the contents of the error variant.

This PR loosens this requirement by only including the error value in the panic message.