### PR TITLE
Fix move semantics in `Option` and `Result` macros

### DIFF
--- a/src/assert_err/assert_err.rs
+++ b/src/assert_err/assert_err.rs
@@ -100,6 +100,16 @@ mod test_assert_err_as_result {
         );
         assert_eq!(actual.unwrap_err(), message);
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        let actual = assert_err_as_result!(a);
+        assert!(actual.is_ok());
+    }
 }
 
 /// Assert expression is Err.
@@ -198,6 +208,15 @@ mod test_assert_err {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        assert_err!(a);
+    }
 }
 
 /// Assert expression is Err.
@@ -273,5 +292,14 @@ mod test_debug_assert_err {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        debug_assert_err!(a);
     }
 }

--- a/src/assert_err/assert_err_eq.rs
+++ b/src/assert_err/assert_err_eq.rs
@@ -41,31 +41,29 @@
 macro_rules! assert_err_eq_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a, b) {
-                (Err(a1), Err(b1)) => {
-                    if a1 == b1 {
-                        Ok((a1, b1))
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_err_eq!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_eq.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`,\n",
-                                " b inner: `{:?}`"
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b,
-                            b1
-                        ))
-                    }
-                }
+            // Match by move here because we return the values back to the caller
+            (Err(a), Err(b)) if a == b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Err(a1), Err(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_err_eq!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_eq.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_err_eq!(a, b)`\n",
@@ -161,6 +159,17 @@ mod test_assert_err_eq_as_result {
             " b debug: `Err(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        let actual = assert_err_eq_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -301,6 +310,16 @@ mod test_assert_err_eq {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        assert_err_eq!(a, b);
+    }
 }
 
 /// Assert two expressions are Err and their values are equal.
@@ -407,5 +426,15 @@ mod test_debug_assert_err_eq {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy);
+
+        debug_assert_err_eq!(a, b);
     }
 }

--- a/src/assert_err/assert_err_eq_x.rs
+++ b/src/assert_err/assert_err_eq_x.rs
@@ -41,29 +41,27 @@
 macro_rules! assert_err_eq_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a) {
-                Err(a1) => {
-                    if a1 == b {
-                        Ok(a1)
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_err_eq_x!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_eq_x.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`",
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b
-                        ))
-                    }
-                }
+            // Match by move here because we return the value back to the caller
+            (Err(a), b) if a == b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a) {
+                Err(a1) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_err_eq_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_eq_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_err_eq_x!(a, b)`\n",
@@ -157,6 +155,17 @@ mod test_assert_err_eq_x_as_result {
             " b debug: `1`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b = NoCopy;
+
+        let actual = assert_err_eq_x_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -294,6 +303,16 @@ mod test_assert_err_eq_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b = NoCopy;
+
+        assert_err_eq_x!(a, b);
+    }
 }
 
 /// Assert an expression is Err and its value is equal to an expression.
@@ -399,5 +418,15 @@ mod test_debug_assert_err_eq_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy);
+        let b = NoCopy;
+
+        debug_assert_err_eq_x!(a, b);
     }
 }

--- a/src/assert_err/assert_err_ne.rs
+++ b/src/assert_err/assert_err_ne.rs
@@ -41,31 +41,29 @@
 macro_rules! assert_err_ne_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a, b) {
-                (Err(a1), Err(b1)) => {
-                    if a1 != b1 {
-                        Ok((a1, b1))
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_err_ne!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_ne.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`,\n",
-                                " b inner: `{:?}`"
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b,
-                            b1
-                        ))
-                    }
-                }
+            // Match by move here because we return the values back to the caller
+            (Err(a), Err(b)) if a != b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Err(a1), Err(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_err_ne!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_ne.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_err_ne!(a, b)`\n",
@@ -201,6 +199,17 @@ mod test_assert_err_ne_as_result {
             " b debug: `Err(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy(2));
+
+        let actual = assert_err_ne_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -341,6 +350,16 @@ mod test_assert_err_ne {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy(2));
+
+        assert_err_ne!(a, b);
+    }
 }
 
 /// Assert two expressions are Err and their values are not equal.
@@ -444,5 +463,15 @@ mod test_debug_assert_err_ne {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Err(NoCopy(2));
+
+        debug_assert_err_ne!(a, b);
     }
 }

--- a/src/assert_err/assert_err_ne_x.rs
+++ b/src/assert_err/assert_err_ne_x.rs
@@ -41,29 +41,27 @@
 macro_rules! assert_err_ne_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a) {
-                Err(a1) => {
-                    if a1 != b {
-                        Ok(a1)
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_err_ne_x!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_ne_x.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`",
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b
-                        ))
-                    }
-                }
+            // Match by move here because we return the value back to the caller
+            (Err(a), b) if a != b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a) {
+                Err(a1) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_err_ne_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_err_ne_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_err_ne_x!(a, b)`\n",
@@ -198,6 +196,17 @@ mod test_assert_err_ne_x_as_result {
             " b debug: `2`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b = NoCopy(2);
+
+        let actual = assert_err_ne_x_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -335,6 +344,16 @@ mod test_assert_err_ne_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b = NoCopy(2);
+
+        assert_err_ne_x!(a, b);
+    }
 }
 
 /// Assert an expression is Err and its value is not equal to an expression.
@@ -440,5 +459,15 @@ mod test_debug_assert_err_ne_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Err(NoCopy(1));
+        let b = NoCopy(2);
+
+        debug_assert_err_ne_x!(a, b);
     }
 }

--- a/src/assert_ok/assert_ok.rs
+++ b/src/assert_ok/assert_ok.rs
@@ -100,6 +100,16 @@ mod test_assert_ok_as_result {
         );
         assert_eq!(actual.unwrap_err(), message);
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        let actual = assert_ok_as_result!(a);
+        assert!(actual.is_ok())
+    }
 }
 
 /// Assert expression is Ok.
@@ -198,6 +208,15 @@ mod test_assert_ok {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        assert_ok!(a);
+    }
 }
 
 /// Assert expression is Ok.
@@ -273,5 +292,14 @@ mod test_debug_assert_ok {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        debug_assert_ok!(a);
     }
 }

--- a/src/assert_ok/assert_ok_eq.rs
+++ b/src/assert_ok/assert_ok_eq.rs
@@ -41,31 +41,29 @@
 macro_rules! assert_ok_eq_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a, b) {
-                (Ok(a1), Ok(b1)) => {
-                    if a1 == b1 {
-                        Ok((a1, b1))
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_ok_eq!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_eq.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`,\n",
-                                " b inner: `{:?}`"
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b,
-                            b1
-                        ))
-                    }
-                }
+            // Match by move here because we return the values back to the caller
+            (Ok(a), Ok(b)) if a == b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Ok(a1), Ok(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_ok_eq!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_eq.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_ok_eq!(a, b)`\n",
@@ -161,6 +159,17 @@ mod test_assert_ok_eq_as_result {
             " b debug: `Ok(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        let actual = assert_ok_eq_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -301,6 +310,16 @@ mod test_assert_ok_eq {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        assert_ok_eq!(a, b);
+    }
 }
 
 /// Assert two expressions are Ok and their values are equal.
@@ -407,5 +426,15 @@ mod test_debug_assert_ok_eq {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy);
+
+        debug_assert_ok_eq!(a, b);
     }
 }

--- a/src/assert_ok/assert_ok_eq_x.rs
+++ b/src/assert_ok/assert_ok_eq_x.rs
@@ -41,29 +41,27 @@
 macro_rules! assert_ok_eq_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a) {
-                Ok(a1) => {
-                    if a1 == b {
-                        Ok(a1)
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_ok_eq_x!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_eq_x.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`",
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b
-                        ))
-                    }
-                }
+            // Match by move here because we return the value back to the caller
+            (Ok(a), b) if a == b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a) {
+                Ok(a1) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_ok_eq_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_eq_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_ok_eq_x!(a, b)`\n",
@@ -158,6 +156,17 @@ mod test_assert_ok_eq_x_as_result {
             " b debug: `1`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b = NoCopy;
+
+        let actual = assert_ok_eq_x_as_result!(a, b);
+        assert!(actual.is_ok());
     }
 }
 
@@ -295,6 +304,16 @@ mod test_assert_ok_eq_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b = NoCopy;
+
+        assert_ok_eq_x!(a, b);
+    }
 }
 
 /// Assert an expression is Ok and its value is equal to an expression.
@@ -400,5 +419,15 @@ mod test_debug_assert_ok_eq_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy);
+        let b = NoCopy;
+
+        debug_assert_ok_eq_x!(a, b);
     }
 }

--- a/src/assert_ok/assert_ok_ne.rs
+++ b/src/assert_ok/assert_ok_ne.rs
@@ -41,31 +41,29 @@
 macro_rules! assert_ok_ne_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a, b) {
-                (Ok(a1), Ok(b1)) => {
-                    if a1 != b1 {
-                        Ok((a1, b1))
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_ok_ne!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_ne.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`,\n",
-                                " b inner: `{:?}`"
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b,
-                            b1
-                        ))
-                    }
-                }
+            // Match by move here because we return the values back to the caller
+            (Ok(a), Ok(b)) if a != b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Ok(a1), Ok(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_ok_ne!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_ne.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_ok_ne!(a, b)`\n",
@@ -201,6 +199,17 @@ mod test_assert_ok_ne_as_result {
             " b debug: `Ok(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy(2));
+
+        let actual = assert_ok_ne_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -341,6 +350,16 @@ mod test_assert_ok_ne {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy(2));
+
+        assert_ok_ne!(a, b);
+    }
 }
 
 /// Assert two expressions are Ok and their values are not equal.
@@ -444,5 +463,15 @@ mod test_debug_assert_ok_ne {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b: Result<NoCopy, NoCopy> = Ok(NoCopy(2));
+
+        debug_assert_ok_ne!(a, b);
     }
 }

--- a/src/assert_ok/assert_ok_ne_x.rs
+++ b/src/assert_ok/assert_ok_ne_x.rs
@@ -41,29 +41,27 @@
 macro_rules! assert_ok_ne_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (a, b) => match (a) {
-                Ok(a1) => {
-                    if a1 != b {
-                        Ok((a1))
-                    } else {
-                        Err(format!(
-                            concat!(
-                                "assertion failed: `assert_ok_ne_x!(a, b)`\n",
-                                "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_ne_x.html\n",
-                                " a label: `{}`,\n",
-                                " a debug: `{:?}`,\n",
-                                " a inner: `{:?}`,\n",
-                                " b label: `{}`,\n",
-                                " b debug: `{:?}`",
-                            ),
-                            stringify!($a),
-                            a,
-                            a1,
-                            stringify!($b),
-                            b
-                        ))
-                    }
-                }
+            // Match by move here because we return the values back to the caller
+            (Ok(a), b) if a != b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a) {
+                Ok(a1) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_ok_ne_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_ok_ne_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
                 _ => Err(format!(
                     concat!(
                         "assertion failed: `assert_ok_ne_x!(a, b)`\n",
@@ -198,6 +196,17 @@ mod test_assert_ok_ne_x_as_result {
             " b debug: `2`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b = NoCopy(2);
+
+        let actual = assert_ok_ne_x_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -335,6 +344,16 @@ mod test_assert_ok_ne_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b = NoCopy(2);
+
+        assert_ok_ne_x!(a, b);
+    }
 }
 
 /// Assert an expression is Ok and its value is not equal to an expression.
@@ -440,5 +459,15 @@ mod test_debug_assert_ok_ne_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Result<NoCopy, NoCopy> = Ok(NoCopy(1));
+        let b = NoCopy(2);
+
+        debug_assert_ok_ne_x!(a, b);
     }
 }

--- a/src/assert_some/assert_some_eq.rs
+++ b/src/assert_some/assert_some_eq.rs
@@ -44,44 +44,44 @@
 macro_rules! assert_some_eq_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (Some(a1), Some(b1)) => {
-                if a1 == b1 {
-                    Ok((a1, b1))
-                } else {
-                    Err(format!(
-                        concat!(
-                            "assertion failed: `assert_some_eq!(a, b)`\n",
-                            "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq.html\n",
-                            " a label: `{}`,\n",
-                            " a debug: `{:?}`,\n",
-                            " a inner: `{:?}`,\n",
-                            " b label: `{}`,\n",
-                            " b debug: `{:?}`,\n",
-                            " b inner: `{:?}`"
-                        ),
-                        stringify!($a),
-                        $a,
-                        a1,
-                        stringify!($b),
-                        $b,
-                        b1
-                    ))
-                }
+            // Match by move here because we return the values back to the caller
+            (Some(a), Some(b)) if a == b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Some(a1), Some(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_eq!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
+                _ => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_eq!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    stringify!($b),
+                    b,
+                )),
             }
-            _ => Err(format!(
-                concat!(
-                    "assertion failed: `assert_some_eq!(a, b)`\n",
-                    "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq.html\n",
-                    " a label: `{}`,\n",
-                    " a debug: `{:?}`,\n",
-                    " b label: `{}`,\n",
-                    " b debug: `{:?}`",
-                ),
-                stringify!($a),
-                $a,
-                stringify!($b),
-                $b,
-            )),
         }
     };
 }
@@ -162,6 +162,17 @@ mod test_assert_some_eq_as_result {
             " b debug: `Some(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b: Option<NoCopy> = Some(NoCopy);
+
+        let actual = assert_some_eq_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -302,6 +313,16 @@ mod test_assert_some_eq {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b: Option<NoCopy> = Some(NoCopy);
+
+        assert_some_eq!(a, b);
+    }
 }
 
 /// Assert two expressions are Some and their values are equal.
@@ -408,5 +429,15 @@ mod test_debug_assert_some_eq {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b: Option<NoCopy> = Some(NoCopy);
+
+        debug_assert_some_eq!(a, b);
     }
 }

--- a/src/assert_some/assert_some_eq_x.rs
+++ b/src/assert_some/assert_some_eq_x.rs
@@ -43,43 +43,43 @@
 #[macro_export]
 macro_rules! assert_some_eq_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
-        match ($a) {
-            Some(a1) => {
-                if a1 == $b {
-                    Ok(a1)
-                } else {
-                    Err(format!(
-                        concat!(
-                            "assertion failed: `assert_some_eq_x!(a, b)`\n",
-                            "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq_x.html\n",
-                            " a label: `{}`,\n",
-                            " a debug: `{:?}`,\n",
-                            " a inner: `{:?}`,\n",
-                            " b label: `{}`,\n",
-                            " b debug: `{:?}`"
-                        ),
-                        stringify!($a),
-                        $a,
-                        a1,
-                        stringify!($b),
-                        $b
-                    ))
-                }
+        match ($a, $b) {
+            // Match by move here because we return the value back to the caller
+            (Some(a), b) if a == b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Some(a1), b) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_eq_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
+                _ => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_eq_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    stringify!($b),
+                    b,
+                )),
             }
-            _ => Err(format!(
-                concat!(
-                    "assertion failed: `assert_some_eq_x!(a, b)`\n",
-                    "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_eq_x.html\n",
-                    " a label: `{}`,\n",
-                    " a debug: `{:?}`,\n",
-                    " b label: `{}`,\n",
-                    " b debug: `{:?}`",
-                ),
-                stringify!($a),
-                $a,
-                stringify!($b),
-                $b,
-            )),
         }
     };
 }
@@ -159,6 +159,17 @@ mod test_assert_some_eq_x_as_result {
             " b debug: `1`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b = NoCopy;
+
+        let actual = assert_some_eq_x_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -296,6 +307,16 @@ mod test_assert_some_eq_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b = NoCopy;
+
+        assert_some_eq_x!(a, b);
+    }
 }
 
 /// Assert an expression is Some and its value is equal to an expression.
@@ -401,5 +422,15 @@ mod test_debug_assert_some_eq_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy;
+        let a: Option<NoCopy> = Some(NoCopy);
+        let b = NoCopy;
+
+        debug_assert_some_eq_x!(a, b);
     }
 }

--- a/src/assert_some/assert_some_ne.rs
+++ b/src/assert_some/assert_some_ne.rs
@@ -44,44 +44,44 @@
 macro_rules! assert_some_ne_as_result {
     ($a:expr, $b:expr $(,)?) => {
         match ($a, $b) {
-            (Some(a1), Some(b1)) => {
-                if a1 != b1 {
-                    Ok((a1, b1))
-                } else {
-                    Err(format!(
-                        concat!(
-                            "assertion failed: `assert_some_ne!(a, b)`\n",
-                            "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne.html\n",
-                            " a label: `{}`,\n",
-                            " a debug: `{:?}`,\n",
-                            " a inner: `{:?}`,\n",
-                            " b label: `{}`,\n",
-                            " b debug: `{:?}`,\n",
-                            " b inner: `{:?}`"
-                        ),
-                        stringify!($a),
-                        $a,
-                        a1,
-                        stringify!($b),
-                        $b,
-                        b1
-                    ))
-                }
+            // Match by move here because we return the values back to the caller
+            (Some(a), Some(b)) if a != b => Ok((a, b)),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Some(a1), Some(b1)) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_ne!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`,\n",
+                        " b inner: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b,
+                    b1
+                )),
+                _ => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_ne!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    stringify!($b),
+                    b,
+                )),
             }
-            _ => Err(format!(
-                concat!(
-                    "assertion failed: `assert_some_ne!(a, b)`\n",
-                    "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne.html\n",
-                    " a label: `{}`,\n",
-                    " a debug: `{:?}`,\n",
-                    " b label: `{}`,\n",
-                    " b debug: `{:?}`",
-                ),
-                stringify!($a),
-                $a,
-                stringify!($b),
-                $b,
-            )),
         }
     };
 }
@@ -202,6 +202,17 @@ mod test_assert_some_ne_as_result {
             " b debug: `Some(1)`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b: Option<NoCopy> = Some(NoCopy(2));
+
+        let actual = assert_some_ne_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -342,6 +353,16 @@ mod test_assert_some_ne {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b: Option<NoCopy> = Some(NoCopy(2));
+
+        assert_some_ne!(a, b);
+    }
 }
 
 /// Assert two expressions are Some and their values are not equal.
@@ -448,5 +469,15 @@ mod test_debug_assert_some_ne {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b: Option<NoCopy> = Some(NoCopy(2));
+
+        debug_assert_some_ne!(a, b);
     }
 }

--- a/src/assert_some/assert_some_ne_x.rs
+++ b/src/assert_some/assert_some_ne_x.rs
@@ -43,43 +43,43 @@
 #[macro_export]
 macro_rules! assert_some_ne_x_as_result {
     ($a:expr, $b:expr $(,)?) => {
-        match ($a) {
-            Some(a1) => {
-                if a1 != $b {
-                    Ok(a1)
-                } else {
-                    Err(format!(
-                        concat!(
-                            "assertion failed: `assert_some_ne_x!(a, b)`\n",
-                            "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne_x.html\n",
-                            " a label: `{}`,\n",
-                            " a debug: `{:?}`,\n",
-                            " a inner: `{:?}`,\n",
-                            " b label: `{}`,\n",
-                            " b debug: `{:?}`"
-                        ),
-                        stringify!($a),
-                        $a,
-                        a1,
-                        stringify!($b),
-                        $b
-                    ))
-                }
+        match ($a, $b) {
+            // Match by move here because we return the value back to the caller
+            (Some(a), b) if a != b => Ok(a),
+            // Match by borrow here because we need to reference both the inner and outer values.
+            // The outer value would be inaccessible in the format invocation if we moved.
+            (ref a, ref b) => match (a, b) {
+                (Some(a1), b) => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_ne_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " a inner: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`"
+                    ),
+                    stringify!($a),
+                    a,
+                    a1,
+                    stringify!($b),
+                    b
+                )),
+                _ => Err(format!(
+                    concat!(
+                        "assertion failed: `assert_some_ne_x!(a, b)`\n",
+                        "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne_x.html\n",
+                        " a label: `{}`,\n",
+                        " a debug: `{:?}`,\n",
+                        " b label: `{}`,\n",
+                        " b debug: `{:?}`",
+                    ),
+                    stringify!($a),
+                    a,
+                    stringify!($b),
+                    b,
+                )),
             }
-            _ => Err(format!(
-                concat!(
-                    "assertion failed: `assert_some_ne_x!(a, b)`\n",
-                    "https://docs.rs/assertables/10.0.0/assertables/macro.assert_some_ne_x.html\n",
-                    " a label: `{}`,\n",
-                    " a debug: `{:?}`,\n",
-                    " b label: `{}`,\n",
-                    " b debug: `{:?}`",
-                ),
-                stringify!($a),
-                $a,
-                stringify!($b),
-                $b,
-            )),
         }
     };
 }
@@ -199,6 +199,17 @@ mod test_assert_some_ne_x_as_result {
             " b debug: `1`",
         );
         assert_eq!(actual.unwrap_err(), message);
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b = NoCopy(2);
+
+        let actual = assert_some_ne_x_as_result!(a, b);
+        assert!(actual.is_ok())
     }
 }
 
@@ -336,6 +347,16 @@ mod test_assert_some_ne_x {
             message
         );
     }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b = NoCopy(2);
+
+        assert_some_ne_x!(a, b);
+    }
 }
 
 /// Assert an expression is Some and its value is not equal to an expression.
@@ -441,5 +462,15 @@ mod test_debug_assert_some_ne_x {
                 .to_string(),
             message
         );
+    }
+
+    #[test]
+    fn move_semantics() {
+        #[derive(Debug, PartialEq)]
+        struct NoCopy(i8);
+        let a: Option<NoCopy> = Some(NoCopy(1));
+        let b = NoCopy(2);
+
+        debug_assert_some_ne_x!(a, b);
     }
 }


### PR DESCRIPTION
These macros are refactored to output the same results that they always have for values that implement `Copy`, but now also support values that do not implement `Copy`. This is important, as many types deliberately do not implement `Copy` or `Clone`, and move semantics are the default in Rust. Values of these types were unable to be used with these macros, which made testing with them challenging.

This issue missed testing because the values used in tests all implement `Copy` via a blanket `impl`. New tests are added with values that explicitly do not implement `Copy` so that this behavior does not regress.

The fix works by re-ordering match expressions such that they only move values at the last possible moment, and match by reference when the tokens need to be referenced multiple times.

## Additional note

I only encountered issues with the `Result` macros during testing, but did confirm the same issues existed with the `Option` macros. It's possible this issue exists elsewhere in the crate, but I didn't want to dig through the whole thing 😅. If maintainers are aware of other places where a similar matching pattern is implemented as the one fixed in this patch, it is probably worth fixing in those places as well.